### PR TITLE
Bring updates to exporting tasks from 7.2 to 7.4

### DIFF
--- a/modules/ROOT/pages/import-export-packages.adoc
+++ b/modules/ROOT/pages/import-export-packages.adoc
@@ -24,7 +24,7 @@ image::import-export-packages-ad8ef.png[align=center]
 === Importing a Mule Application (Deployable Archive)
 
 . Select *Import* from the *File* menu.
-. In the Import wizard, click to expand the Mule folder, and select *Packaged Mule Application (.jar)*, then click Next.
+. In the Import wizard, click to expand the Mule folder, select *Packaged Mule Application (.jar)*, and click *Next*.
 . In the *File* field, click the ellipses (...) button to explore your local drive. Then select the Mule Deployable Archive file (that is, the `.jar` file) you want to import. +
 If you want, you can change project's name.
 . Click *Finish*.
@@ -36,13 +36,13 @@ See xref:update-workspace.adoc[Updating Workspaces] for more details.
 === Importing a Mule Application (Project From File System)
 
 . Select *Import* from the *File* menu.
-. In the Import wizard, click to expand the Mule folder, and select *Anypoint Studio Project from File System*, then click Next.
+. In the Import wizard, click to expand the Mule folder, select *Anypoint Studio Project from File System*, and click *Next*.
 . In the *Project Root* field, click the ellipses (...) button to explore your local drive, and select the root folder for the Mule project that you want to import. +
 If you want, you can change the project's name and choose a different runtime version in which to run it.
 +
 [NOTE]
 You can choose a different runtime version if you have other embedded runtime versions installed in Studio. +
-See _Mule Runtimes for Anypoint Studio Update Site_ in xref:studio-update-sites.adoc[Anypoint Studio Update Sites] to learn how to install other versions of the runtime in Studio.
+See _Mule Runtimes for Anypoint Studio Update Site_ in xref:studio-update-sites.adoc[About Anypoint Studio Update Sites] to learn how to install other versions of the runtime in Studio.
 
 == Exporting Projects From Studio
 
@@ -56,20 +56,29 @@ image::import-export-packages-a1b21.png[]
 |*Anypoint Studio Project to Mule Deployable Archive (includes Studio metadata)* |Exports a Mule project to a `.jar` deployable file.
 |===
 
-=== Exporting a Studio Project to a Mule Deployable File
+=== Exporting a Studio Project to a Deployable Mule Application
 
 . Select *Export* from the *File* menu.
-. In the Import wizard, click to expand the Mule folder, and select *Anypoint Studio Project to Mule Deployable Archive (includes Studio metadata)*, then click Next.
-. Select the project that you want to export, and click *Next*.
-. In the *JAR file* drop-down menu, click the ellipses (...) button to explore your local drive, and select the folder to which you want to export your JAR deployable file. +
-Additionally, you can choose *Attach Project Sources* to include metadata that Studio requires to re-import the deployable file as an open Mule project into your workspace. +
-This is the same as using the `-DattachMuleSources` flag when packaging using the Mule Maven Plugin. See xref:4.1@mule-runtime::package-task-mmp.adoc[To Package a Mule Application (Mule Maven Plugin)] for more information.
+. In the Import wizard, click to expand the Mule folder, select *Anypoint Studio Project to Mule Deployable Archive (includes Studio metadata)*, and click *Next*.
+. Select the project that you want to export and click *Next*.
+. In the *JAR file* menu, click the ellipses (...) button to explore your local drive, and select the folder to which you want to export your deployable JAR file. +
+Additionally, you can choose *Attach Project Sources* to include metadata that Studio requires to reimport the deployable file as an open Mule project into your workspace.
 +
-You can also choose *Include Project Modules and Dependencies*. +
-This option creates a heavy package with all the dependencies of your project already packaged in your app. This is required to deploy your app to CloudHub. +
-If you uncheck this option, Studio exports your project in a lightweight package. This is useful if you want to distribute your project to other Studio installations because it only keeps a reference to all its dependencies. When re-importing it to Studio, all your dependencies will be automatically downloaded.
+You must keep the *Attach Project Sources* option selected to be able to import the packaged JAR file back into a Studio workspace. This is the same as using the `-DattachMuleSources` flag when packaging using the Mule Maven Plugin. See xref:mule-runtime::mmp-concept.adoc#create-an-application-package-to-import-into-anypoint-studio[Create an Application Package to Import into Anypoint Studio] in the Mule Maven Plugin documentation for more information.
+
+=== Exporting a Studio Project to a Shareable Lightweight Package
+
+. Select *Export* from the *File* menu.
+. In the Import wizard, click to expand the Mule folder, select *Anypoint Studio Project to Mule Deployable Archive (includes Studio metadata)*, and click *Next*.
+. Select the project that you want to export and click *Next*.
+. In the *JAR file* menu, click the ellipses (...) button to explore your local drive, and select the folder to which you want to export your JAR deployable file.
+. Deselect the *Include project modules and dependencies* option.  +
+This option skips bundling the actual modules and external dependencies required to run the Mule application in a Mule runtime engine, creating a lightweight JAR file package that does not include any dependencies specified in the Mule application's `pom.xml` file.
++
+The generated JAR file is not a functional deployable archive and cannot be deployed to a Mule runtime engine, but instead offers a way to archive only the source files that make up the Mule application. This is the same as using the `-lightWeightPackage` flag when packaging using the Mule Maven Plugin and is useful if you want to distribute your project to other Studio installations because it only keeps a reference to all its dependencies. When you import a lightweight package into Studio, all your dependencies are automatically downloaded. See xref:mule-runtime::mmp-concept.adoc#create-a-lightweight-package[Create a Lightweight Package] in the Mule Maven Plugin documentation for more information.
+
+
 
 == See Also
 
-* xref:mule-runtime::packager-concept.adoc[Mule Packager Tool]
-* xref:import-project-exchange.adoc[Importing a Mule Project from Exchange]
+* xref:import-project-exchange.adoc[To Import a Mule Project from Exchange]


### PR DESCRIPTION
This was already reviewed and edited in #60

The changes are the same, just for a different version.