### PR TITLE
Syntax and style corrections 

### DIFF
--- a/modules/ROOT/pages/update-workspace.adoc
+++ b/modules/ROOT/pages/update-workspace.adoc
@@ -3,9 +3,9 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Anypoint Studio 7.2 and later simplifies the configuration of the `mule-artifact.json` file. This file is used when packaging your Mule application to identify the class loader configuration and settings of your Mule application, and the minimum required Mule runtime version to run your application. +
+Anypoint Studio 7.2 and later simplifies the configuration of the `mule-artifact.json` file. This file is used when packaging your Mule application to identify the class loader configuration and settings of your Mule application, and the minimum required Mule runtime engine version to run your application.
 
-Anypoint Studio includes a new version of the Mule Maven Plugin that can automatically infer some of this required metadata. This make it easier for you to keep track of all the declarations you need to make when exporting resources. +
+Anypoint Studio includes a new version of the Mule Maven Plugin that can automatically infer some of this required metadata. This make it easier for you to keep track of all the declarations you need to make when exporting resources.
 
 
 [%header%autowidth.spread,cols="a,a"]
@@ -43,12 +43,11 @@ Anypoint Studio includes a new version of the Mule Maven Plugin that can automat
 ----
 |===
 
-Note that this simplification is meant to reduce the number of declarations you need to keep track at development time using Anypoint Studio. A fully configured 'mule-artifact.json' is still required by the runtime when executing the packaged application. You can find the generated 'mule-artifact.json' file inside the `target` directory after packaging.
+Note that this simplification is meant to reduce the number of declarations you need to keep track at development time using Anypoint Studio. A fully configured `mule-artifact.json` is still required by Mule runtime engine when executing the packaged application. You can find the generated `mule-artifact.json` file inside the `target` directory after packaging.
 
-The Mule Maven plugin checks the metadata declared in 'mule-artifact.json'. If there is a value that is not declared, the Mule Maven Plugin infers it from the application code before packaging.
+The Mule Maven plugin inspects the metadata declared in `mule-artifact.json`. If there is a value that is not declared, the Mule Maven Plugin infers it from the application code before packaging. If there are other metadata declared, it uses that information to package the application.
 
-If there are other metadata declared, it uses that information to package the application. +
-If you choose to update to the latest Mule Maven plugin, and to keep your old descriptor files, you'll need to manually keep track of your descriptors metadata.
+If you choose to update to the latest Mule Maven plugin, and want to keep your old descriptor files, you'll need to manually keep track of your descriptors metadata.
 
 == Upgrading From 7.1.x to 7.2 and later
 
@@ -56,15 +55,21 @@ When you open Anypoint Studio 7.2 and use a workspace created with previous vers
 
 image::this-766bb.png[align=center]
 
-Note that Studio lists all the projects whose configurations need updating. +
-Keep in mind that Anypoint Studio does not consider closed projects for this migration.
+Note that Studio lists all the projects whose configurations need updating and that it does not consider closed projects for this migration.
 
 Clicking *Perform update* enables Studio to:
 
 * Update the Mule Maven Plugin version in the pom.xml file of your projects listed in this dialog.
-* Remove all declarations from the 'mule-artifact.json' files of the same listed projects. +
- This process overwrites your existing 'mule-artifact.json'. If you have other declarations in your 'mule-artifact.json' that you want to preserve (for example, secureProperties declarations, redeploymentEnabled, etc.), you should back up those files outside of your workspace, perform the migration, and then restore your old 'mule-artifact.json' files. +
-We strongly recommend not to preserve the following declarations: configs, name, requiredProduct, classLoaderModelLoaderDescriptor and bundleDescriptorLoader
+* Remove all declarations from the `mule-artifact.json` files of the same listed projects. +
+This process overwrites your existing `mule-artifact.json`. If you have other declarations in your `mule-artifact.json` that you want to preserve (for example, secureProperties declarations, redeploymentEnabled, etc.), you should back up those files outside of your workspace, perform the migration, and then restore your old `mule-artifact.json` files.
+
+MuleSoft strongly recommends not to preserve the following declarations:
+
+** `configs`
+** `name`
+** `requiredProduct`
+** `classLoaderModelLoaderDescriptor`
+** `bundleDescriptorLoader`
 
 
 == See Also

--- a/modules/ROOT/pages/update-workspace.adoc
+++ b/modules/ROOT/pages/update-workspace.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 Anypoint Studio 7.2 and later simplifies the configuration of the `mule-artifact.json` file. This file is used when packaging your Mule application to identify its class loader configuration and settings, and the minimum required Mule runtime engine version to run your application.
 
-Anypoint Studio includes a new version of the Mule Maven Plugin that can automatically infer some of this required metadata. This make it easier for you to keep track of all the declarations you need to make when exporting resources.
+Anypoint Studio includes a new version of the Mule Maven Plugin that can automatically infer some of this required metadata. This makes it easier for you to keep track of all the declarations you need to make when exporting resources.
 
 
 [%header%autowidth.spread,cols="a,a"]
@@ -47,7 +47,8 @@ Note that this simplification is meant to reduce the number of declarations you 
 
 The plugin inspects the metadata declared in `mule-artifact.json`. If there is a value that is not declared, the plugin infers it from the application code before packaging. If other metadata is declared, the plugin uses that information to package the application.
 
-If you choose to update to the latest Mule Maven plugin, and want to keep your old descriptor files, you'll need to manually keep track of your descriptors metadata.
+If you choose to update to the latest plugin and want to keep your old descriptor files, you'll need to manually keep track of your descriptor metadata.
+
 
 == Upgrading from Studio 7.1.x to 7.2 and later
 
@@ -55,13 +56,14 @@ When you open Anypoint Studio 7.2 and use a workspace created with previous vers
 
 image::this-766bb.png[align=center]
 
-Note that Studio lists all the projects whose configurations need updating and that it does not consider closed projects for this migration.
+Note that Studio lists only the projects whose configurations need updating; it does not list closed projects.
 
 Clicking *Perform update* enables Studio to:
 
 * Update the Mule Maven Plugin version in the pom.xml file of your projects listed in this dialog.
 * Remove all declarations from the `mule-artifact.json` files of the same listed projects. +
-This process overwrites your existing `mule-artifact.json`. If you have other declarations in your `mule-artifact.json` that you want to preserve (for example, secureProperties declarations, redeploymentEnabled, etc.), you should back up those files outside of your workspace, perform the migration, and then restore your old `mule-artifact.json` files.
+This process overwrites your existing `mule-artifact.json` file. If you have other declarations in `mule-artifact.json` that you want to preserve (for example, `secureProperties`, `redeploymentEnabled`, and so on), you should back up those files outside of your workspace, perform the migration, and then restore your old `mule-artifact.json` files.
+
 
 Do not to preserve the following declarations:
 

--- a/modules/ROOT/pages/update-workspace.adoc
+++ b/modules/ROOT/pages/update-workspace.adoc
@@ -43,7 +43,7 @@ Anypoint Studio includes a new version of the Mule Maven Plugin that can automat
 ----
 |===
 
-Note that this simplification is meant to reduce the number of declarations you need to keep track at development time using Anypoint Studio. A fully configured `mule-artifact.json` is still required by Mule runtime engine when executing the packaged application. You can find the generated `mule-artifact.json` file inside the `target` directory after packaging.
+Note that this simplification is meant to reduce the number of declarations you need to keep track of at development using Anypoint Studio. A fully configured `mule-artifact.json` file is still required by Mule runtime engine when executing the packaged application. You can find the generated `mule-artifact.json` file inside the `target` directory after packaging.
 
 The Mule Maven plugin inspects the metadata declared in `mule-artifact.json`. If there is a value that is not declared, the Mule Maven Plugin infers it from the application code before packaging. If there are other metadata declared, it uses that information to package the application.
 

--- a/modules/ROOT/pages/update-workspace.adoc
+++ b/modules/ROOT/pages/update-workspace.adoc
@@ -63,7 +63,7 @@ Clicking *Perform update* enables Studio to:
 * Remove all declarations from the `mule-artifact.json` files of the same listed projects. +
 This process overwrites your existing `mule-artifact.json`. If you have other declarations in your `mule-artifact.json` that you want to preserve (for example, secureProperties declarations, redeploymentEnabled, etc.), you should back up those files outside of your workspace, perform the migration, and then restore your old `mule-artifact.json` files.
 
-MuleSoft strongly recommends not to preserve the following declarations:
+Do not to preserve the following declarations:
 
 ** `configs`
 ** `name`

--- a/modules/ROOT/pages/update-workspace.adoc
+++ b/modules/ROOT/pages/update-workspace.adoc
@@ -49,7 +49,7 @@ The plugin inspects the metadata declared in `mule-artifact.json`. If there is a
 
 If you choose to update to the latest Mule Maven plugin, and want to keep your old descriptor files, you'll need to manually keep track of your descriptors metadata.
 
-== Upgrading From 7.1.x to 7.2 and later
+== Upgrading from Studio 7.1.x to 7.2 and later
 
 When you open Anypoint Studio 7.2 and use a workspace created with previous versions, Studio pops up a note:
 

--- a/modules/ROOT/pages/update-workspace.adoc
+++ b/modules/ROOT/pages/update-workspace.adoc
@@ -45,7 +45,7 @@ Anypoint Studio includes a new version of the Mule Maven Plugin that can automat
 
 Note that this simplification is meant to reduce the number of declarations you need to keep track of at development using Anypoint Studio. A fully configured `mule-artifact.json` file is still required by Mule runtime engine when executing the packaged application. You can find the generated `mule-artifact.json` file inside the `target` directory after packaging.
 
-The Mule Maven plugin inspects the metadata declared in `mule-artifact.json`. If there is a value that is not declared, the Mule Maven Plugin infers it from the application code before packaging. If there are other metadata declared, it uses that information to package the application.
+The plugin inspects the metadata declared in `mule-artifact.json`. If there is a value that is not declared, the plugin infers it from the application code before packaging. If other metadata is declared, the plugin uses that information to package the application.
 
 If you choose to update to the latest Mule Maven plugin, and want to keep your old descriptor files, you'll need to manually keep track of your descriptors metadata.
 

--- a/modules/ROOT/pages/update-workspace.adoc
+++ b/modules/ROOT/pages/update-workspace.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Anypoint Studio 7.2 and later simplifies the configuration of the `mule-artifact.json` file. This file is used when packaging your Mule application to identify the class loader configuration and settings of your Mule application, and the minimum required Mule runtime engine version to run your application.
+Anypoint Studio 7.2 and later simplifies the configuration of the `mule-artifact.json` file. This file is used when packaging your Mule application to identify its class loader configuration and settings, and the minimum required Mule runtime engine version to run your application.
 
 Anypoint Studio includes a new version of the Mule Maven Plugin that can automatically infer some of this required metadata. This make it easier for you to keep track of all the declarations you need to make when exporting resources.
 


### PR DESCRIPTION
This article was displaying incorrect tagging for file names. 
Also updating terms such as "runtime" to "Mule runtime engine".