### PR TITLE
Document API project creation in Studio 7.7

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -16,6 +16,8 @@
 
 * xref:api-development-studio.adoc[API Development in Studio]
 
+* xref:create-api-specification-studio.adoc[Create an API Project in Studio]
+
 * xref:api-sync.adoc[API Sync]
  ** xref:sync-api-projects-design-center.adoc[Synchronize API Specifications with Design Center]
  ** xref:sync-imported-api-specifications-design-center.adoc[Edit Imported API Specifications in Your Projects in Studio]

--- a/modules/ROOT/pages/api-sync.adoc
+++ b/modules/ROOT/pages/api-sync.adoc
@@ -6,15 +6,15 @@ endif::[]
 
 The API Sync feature of Anypoint Studio enables you to:
 
-* Start designing an API project in Studio and synchronize it with Design Center.
-* Pull a published RAML or OAS 2.0 API specification from Exchange or a private Maven repository, into your Mule application project in Studio to scaffold a new project. +
+* Start designing a RAML, or OAS 2.0 and 3.0 API specification in Studio and synchronize it with Design Center.
+* Pull a published RAML or OAS 2.0 and 3.0 API specification from Exchange or a private Maven repository, into your Mule application project in Studio to scaffold a new project. +
 API sync also enables you to edit the API specification you imported from Exchange, and push your changes to Design Center.
 +
 You can use API Sync on more than one API specification to scaffold multiple flows in different Mule configuration files.
 * Monitor the API versions that you implemented in your project and update your flows based on the latest published version.
-* Pull a RAML or OAS 2.0 API specification from Design Center into Studio, edit the specification offline, and pull the updates back to Design Center.
+* Pull a RAML or OAS 2.0 and 3.0 API specification from Design Center into Studio, edit the specification offline, and pull the updates back to Design Center.
 
-API Sync supports importing both RAML and OAS 2.0 specifications.
+API Sync supports importing both RAML, OAS 2.0 and OAS 3.0 specifications.
 
 API Sync comes bundled by default in Studio 7.4.x and later, and requires Mule 4.1.4 and later.
 

--- a/modules/ROOT/pages/api-sync.adoc
+++ b/modules/ROOT/pages/api-sync.adoc
@@ -6,6 +6,7 @@ endif::[]
 
 The API Sync feature of Anypoint Studio enables you to:
 
+* Start designing an API project in Studio and synchronize it with Design Center.
 * Pull a published RAML or OAS 2.0 API specification from Exchange or a private Maven repository, into your Mule application project in Studio to scaffold a new project. +
 API sync also enables you to edit the API specification you imported from Exchange, and push your changes to Design Center.
 +
@@ -21,6 +22,14 @@ API sync might not work properly if the RAML file exceeds 4,000 lines of text.
 
 Using API Sync, you can develop your Mule applications following API Lifecycle development practices.
 
+== Create an API Specification in Studio
+
+. Start a new API project in Studio.
+See xref:create-api-specification-studio.adoc[Create an API Project in Studio] for more information.
+. Publish it to Exchange.
+. Import the same API specification from Exchange to your Studio project. +
+See xref:import-api-specification-exchange.adoc[Importing an API Specification from Exchange] for more information.
+
 == Import an API Specification from Exchange into a New Mule Project
 
 . Create an API specification in Design Center. +
@@ -29,9 +38,6 @@ You can either xref:design-center::design-create-publish-api-raml-editor.adoc[Cr
 See xref:design-center::design-publish.adoc[Publish an API Specification] for more information.
 . Import the same API specification from Exchange to your Studio project. +
 See xref:import-api-specification-exchange.adoc[Importing an API Specification from Exchange] for more information.
-
-// It is not possible to create a new API version from Studio and then upload it to Exchange.
-// Change your API specification in Design Center, publish a new version to Exchange, and then update your local Studio implementation using API Sync:
 
 You can keep your Studio projects updated to the latest version of the API specification:
 

--- a/modules/ROOT/pages/create-api-specification-studio.adoc
+++ b/modules/ROOT/pages/create-api-specification-studio.adoc
@@ -2,6 +2,8 @@
 
 Anypoint Studio 7.7 and later enables you to create a RAML or OAS 2.0 and 3.0 API specification, or an API fragment in Studio and automatically synchronize it with Design Center.
 
+It is not possible to create a flow out of an OAS 3.0 API specification.
+
 [NOTE]
 Studio uses the EGit plugin only for the VCS feature of editing API specifications offline. Studio does not support the EGit plugin for Mule application projects that you might track using your own VCS.
 
@@ -16,7 +18,7 @@ To start creating an API project in Studio, you must be logged in to Anypoint Pl
 
 Studio prompts you to switch to the API design perspective.
 
-In the API design perspective, use the API editor to write your API specification or API fragment.
+In the API design perspective, use the API editor to write your API specification or API fragment. Additionally, you can use the API Console view to mock a live service so you can test your API specification.
 
 Studio uses VCS to track the development of your API project and keep it syncronized with Design Center.
 

--- a/modules/ROOT/pages/create-api-specification-studio.adoc
+++ b/modules/ROOT/pages/create-api-specification-studio.adoc
@@ -24,12 +24,15 @@ Studio uses VCS to track the development of your API project and keep it syncron
 
 Using a different branch allows you to modify the API definition without risking pushing those changes to the main branch in Design Center.
 
+include::page$sync-api-projects-design-center.adoc[tag=create-branch-vcs]
 
+include::page$sync-api-projects-design-center.adoc[tag=commit-to-branch-vcs]
 
 == Merge and Push Your API Project
 
 You can merge the changes made to your API specification to your main branch and synchronize it with Design Center
 
+include::page$sync-api-projects-design-center.adoc[tag=merge-and-push-to-main-vcs]
 
 == See Also
 

--- a/modules/ROOT/pages/create-api-specification-studio.adoc
+++ b/modules/ROOT/pages/create-api-specification-studio.adoc
@@ -1,0 +1,36 @@
+= Create an API Project in Studio
+
+Anypoint Studio 7.7 and later enables you to create a RAML or OAS 2.0 and 3.0 API specification, or an API fragment in Studio and automatically synchronize it with Design Center.
+
+[NOTE]
+Studio uses the EGit plugin only for the VCS feature of editing API specifications offline. Studio does not support the EGit plugin for Mule application projects that you might track using your own VCS.
+
+To start creating an API project in Studio, you must be logged in to Anypoint Platform. See xref:xref:set-credentials-in-studio-to.adoc[Configure Platform Credentials].
+
+. In the taskbar at the top of the Anypoint Studio display, select *File* > *New* > *API Specificiation*.
+. Select the type of API project that you want to create.
+** To create a new API specification, select the *New API Specification* tab, and then select the type of API.
+** To create an API fragment, select the the *New API Fragment* tab, and then select the type of API fragment.
+. Type a name for your project.
+. Select *Finish*.
+
+Studio prompts you to switch to the API design perspective.
+
+In the API design perspective, use the API editor to write your API specification or API fragment.
+
+Studio uses VCS to track the development of your API project and keep it syncronized with Design Center.
+
+== Create Branches
+
+Using a different branch allows you to modify the API definition without risking pushing those changes to the main branch in Design Center.
+
+
+
+== Merge and Push Your API Project
+
+You can merge the changes made to your API specification to your main branch and synchronize it with Design Center
+
+
+== See Also
+
+* xref:import-api-specification-exchange.adoc[Import an API Specification from Exchange]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -94,7 +94,7 @@ image::index-7bcca.png[]
 
 == Perspectives
 
-A Perspective in Studio is a collection of views and editors in a specified arrangement. The default perspective is the Mule Design perspective. Studio also supplies a Mule Debug perspective.
+A Perspective in Studio is a collection of views and editors in a specified arrangement. The default perspective is the Mule Design perspective. Studio also supplies a Mule Debug perspective, and an API design perspective.
 
 You can create your own perspectives, and add or remove any of the default views.
 

--- a/modules/ROOT/pages/sync-api-projects-design-center.adoc
+++ b/modules/ROOT/pages/sync-api-projects-design-center.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
+:page-partial:
 
 Anypoint Studio enables you to import a RAML, OAS 2.0, or OAS 3.0 API specification created in Design Center to an API project in Studio so that you can edit it offline and then stage and push your changes as you would do with any version control system (VCS).
 
@@ -33,6 +34,7 @@ Studio imports the API specification as an API project so that you can work on y
 You can create your own branch based on the branch you pulled from Design Center. +
 Using a different branch allows you to modify the API definition without risking pushing those changes to the main branch in Design Center.
 
+// tag::create-branch-vcs[]
 To create a different branch in Studio:
 
 . In the Package Explorer view, right-click your API project and select *Team* > *Switch To* > *New Branch...*.
@@ -48,7 +50,9 @@ When configuring this option, you must select the behavior you want git to have 
 . Select *Finish*.
 
 With a newly created branch, you can start committing your changes.
+// end::create-branch-vcs[]
 
+// tag::commit-to-branch-vcs[]
 [[commit-to-branch]]
 == Commit Changes to Your API Project
 
@@ -74,11 +78,13 @@ See <<push-branch,Push Your Branch to Design Center>> below for more information
 <1> Select *Commit* to add the commit to your local copy.
 
 See xref:git-staging-view-reference.adoc[Git Staging View Reference] for more information about this view.
+// end::commit-to-branch-vcs[]
 
 == Merge Your Changes into the Master Branch
 
 You can merge the changes made in your local branch to the master branch to push to Design Center:
 
+// tag::merge-and-push-to-main-vcs[]
 . In the Package Explorer view, right-click your API project and select *Team* > *Merge* > *Push Branch...*.
 +
 image::merge-menu.png[]
@@ -86,7 +92,6 @@ image::merge-menu.png[]
 +
 image::merge-view.png[]
 . Select *Merge*.
-
 
 [[push-branch]]
 == Push Your Branch to Design Center
@@ -111,6 +116,7 @@ This option force pushes your changes to the branch in Design Center.
 
 In certain scenarios, someone else might have modified the version in Design Center while you modified the same version locally. This triggers conflicts in git. +
 See xref:solving-conflicts-api-projects.adoc[Solving Conflicts] for more information.
+// end::merge-and-push-to-main-vcs[]
 
 == See Also
 


### PR DESCRIPTION
This change adds an article explaining the steps to start an API spec or API fragment from Studio using the API Design perspective.

This early document does not include specific screenshots of the API perspective. 
It also reuses content from the edit an API spec imported from Design Center. Tasks such as [creating branches](https://docs.mulesoft.com/studio/latest/sync-api-projects-design-center#create-branches), [commmitting](https://docs.mulesoft.com/studio/latest/sync-api-projects-design-center#commit-to-branch), [merging](https://docs.mulesoft.com/studio/latest/sync-api-projects-design-center#merge-your-changes-into-the-master-branch), and [pushing to Design Center](https://docs.mulesoft.com/studio/latest/sync-api-projects-design-center#push-branch).
The screenshots in the included content might also need to be updated to reflect the API Design perspective in some places.