### PR TITLE
DOCS-12123: Clarify workaround step for MFA in Windows

### DIFF
--- a/modules/ROOT/pages/browser-settings.adoc
+++ b/modules/ROOT/pages/browser-settings.adoc
@@ -19,13 +19,14 @@ Additionally, if you use Windows you must perform an additional configuration:
 
 . Quit Anypoint Studio if you are running it.
 . Download the latest fixed version of WebView2 from the https://developer.microsoft.com/en-us/microsoft-edge/webview2/[Microsoft Developer Portal^].
+. Extract the `.cab` file with the following command in a Command Prompt (CMD): `Extrac32 /E <path_to_CAB>`
 . Locate your `AnypointStudio.ini` file inside your Anypoint Studio's installation directory.
 . Add the following lines to the `AnypointStudio.ini` file:
 +
 [source]
 --
 -Dorg.eclipse.swt.browser.DefaultType=edge
--Dorg.eclipse.swt.browser.EdgeDir=<path-to-your-WebView2-cab-file>
+-Dorg.eclipse.swt.browser.EdgeDir=<path-to-extracted-WebView2-dir>
 # for example:
 # -Dorg.eclipse.swt.browser.EdgeDir=C:\Users\my-user\Downloads\Microsoft.WebView2.FixedVersionRuntime.9x.x.xx.xx
 --


### PR DESCRIPTION
There was a missing step needed (extract the .cab contents) and the property value referred to the .cab file instead of the extracted directory.

This was causing confusion and unsuccessful use of this workaround.

IMPORTANT: This should be replicated to other versions (branches)