### PR TITLE
W-10736387: Add note about unsupported browser for platform's views.

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -7,16 +7,20 @@ endif::[]
 
 Anypoint Studio is MuleSoft's Eclipse-based integration development environment for designing and testing Mule applications. You can deploy the application and run it on your Mule server.
 
-The same editor also allows you to edit API definition files (in https://raml.org/[RAML] and WSDL), and create domains that define xref:3.8@mule-runtime::shared-resources.adoc[shared resources].
+The same editor also allows you to edit API definition files (in https://raml.org/[RAML] and WSDL), and create domains that define shared resources.
 
-Anypoint Studio 6.5 requires Java 8 to run properly. However, depending on which Mule runtime you want to use, you can configure different JDK versions within Anypoint Studio:
+== Requirements
 
-* Mule 3.9.x requires Studio running on Java 8.
-* Mule 3.5.x requires Studio running on Java 7.
-* Other supported runtime versions work fine with both Java 7 or 8.
 
-[NOTE]
-Studio 6.5 is not compatible with Mule 4.
+* Anypoint Studio 6 requires Java 8 to run properly. However, depending on which Mule runtime you want to use, you can configure different JDK versions within Anypoint Studio:
+
+** Mule 3.9.x requires Studio running on Java 8.
+** Mule 3.5.x requires Studio running on Java 7.
+** Other supported runtime versions work fine with both Java 7 or 8.
+
+* Studio 6 is not compatible with Mule 4.
+
+== Overview
 
 Anypoint Studio offers two parallel tabs that you can utilize to design and craft your applications:
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -11,6 +11,8 @@ The same editor also allows you to edit API definition files (in https://raml.or
 
 == Requirements
 
+* Internet Explorer versions 11 and earlier are not supported. +
+Anypoint Studio uses your system's native browser to display elements of the Anypoint Platform UI. If your system defaults to an Internet Explorer browser, you won't be able to visualize any of the Anypoint Platform views.
 
 * Anypoint Studio 6 requires Java 8 to run properly. However, depending on which Mule runtime you want to use, you can configure different JDK versions within Anypoint Studio:
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -7,7 +7,7 @@ endif::[]
 
 Anypoint Studio is MuleSoft's Eclipse-based integration development environment for designing and testing Mule applications. You can deploy the application and run it on your Mule server.
 
-The same editor also allows you to edit API definition files (in https://raml.org/[RAML] and WSDL), and create domains that define shared resources.
+The same editor also allows you to edit RAML and WSDL API specification files and create domains that define shared resources.
 
 == Requirements
 


### PR DESCRIPTION
Reference: [W-10736387](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000r7ZtmYAE/view)

**Notes**:

- All platform's UIs should not render because of the unsupported browser. Should we document workarounds for other platform's tasks such as "Deploying to CloudHub" and "Publishing an asset to Exchange"?
- Are the instructions on [Troubleshooting Issues with Your Default OS Browser](https://docs.mulesoft.com/studio/6/troubleshooting-studio) deprecated?