### PR TITLE
W-11585544: Fix broken links

### DIFF
--- a/modules/ROOT/pages/anypoint-studio-features.adoc
+++ b/modules/ROOT/pages/anypoint-studio-features.adoc
@@ -70,4 +70,4 @@ https://raml.org/[RAML] is a widely used standard for defining APIs through a ve
 
 == See Also
 
-* xref:6@setting-up-your-development-environment.adoc[Setting Up Your Development Environment]
+* xref:setting-up-your-development-environment.adoc[Setting Up Your Development Environment]

--- a/modules/ROOT/pages/studio-update-sites.adoc
+++ b/modules/ROOT/pages/studio-update-sites.adoc
@@ -48,7 +48,7 @@ Provides:
 
 Read more about xref:apikit::index.adoc[APIkit].
 |*API Gateway Update Site*
-|API Gateway runtime - For initial installation, see xref:6@install-studio-gw.adoc[Install API Gateway Runtime].
+|API Gateway runtime - For initial installation, see xref:install-studio-gw.adoc[Install API Gateway Runtime].
 
 `+http://studio.mulesoft.org/r4/api-gateway/+`
 |*Anypoint Enterprise Security*

--- a/modules/ROOT/pages/studio-visual-debugger.adoc
+++ b/modules/ROOT/pages/studio-visual-debugger.adoc
@@ -18,7 +18,7 @@ Note that the Visual Debugger is completely distinct from the Java Debugger cont
 
 == Assumptions
 
-This document assumes that you are familiar with the xref:index.adoc[Anypoint Studio Essentials], particularly xref:6@index.adoc#building-blocks[Studio Building Blocks]. Review the xref:basic-studio-tutorial.adoc[Getting Started with Mule Studio] chapter to learn more about developing with Mule ESB's graphical user interface.
+This document assumes that you are familiar with the xref:index.adoc[Anypoint Studio Essentials], particularly xref:index.adoc#building-blocks[Studio Building Blocks]. Review the xref:basic-studio-tutorial.adoc[Getting Started with Mule Studio] chapter to learn more about developing with Mule ESB's graphical user interface.
 
 == Prerequisites
 


### PR DESCRIPTION
This PR fixes the broken links to older versions of Studio due to the updated 'version' field.

See

[W-11585544](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000013ulwzYAA/view)
https://github.com/mulesoft/docs-studio/pull/350
https://github.com/mulesoft/docs-studio/pull/351
for more details.