### PR TITLE
[W-11690846] remove leveloffset for v7.6

### DIFF
--- a/modules/ROOT/pages/install-mule-runtime-versions.adoc
+++ b/modules/ROOT/pages/install-mule-runtime-versions.adoc
@@ -2,10 +2,10 @@
 
 include::studio::partial$install-mule-runtime-versions.adoc[tag=intro]
 
-include::studio::partial$install-mule-runtime-versions.adoc[tag=prereq,leveloffset=+1]
+include::studio::partial$install-mule-runtime-versions.adoc[tag=prereq]
 
-include::studio::partial$install-mule-runtime-versions.adoc[tag=install-task,leveloffset=+1]
+include::studio::partial$install-mule-runtime-versions.adoc[tag=install-task]
 
-include::studio::partial$install-mule-runtime-versions.adoc[tag=update-mule-version-task,leveloffset=+1]
+include::studio::partial$install-mule-runtime-versions.adoc[tag=update-mule-version-task]
 
-include::studio::partial$install-mule-runtime-versions.adoc[tag=uninstall-mule-version-task,leveloffset=+1]
+include::studio::partial$install-mule-runtime-versions.adoc[tag=uninstall-mule-version-task]


### PR DESCRIPTION
ref: W-11690846

remove leveloffset for some of the pages to maintain correct heading orders. This is because in the latest version (v7.13), I updated the heading levels to resolve some build warnings for so leveloffset is no longer needed.

Must be merged at the same time as #382.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released