### PR TITLE
[W-11690846] remove leveloffset for v7.10

### DIFF
--- a/modules/ROOT/pages/pce-configuration-macos.adoc
+++ b/modules/ROOT/pages/pce-configuration-macos.adoc
@@ -1,7 +1,7 @@
 = Configure Private Cloud Edition in Studio (macOS)
 
-include::studio::partial$pce-configuration-macos.adoc[tag=intro,leveloffset=+1]
+include::studio::partial$pce-configuration-macos.adoc[tag=intro]
 
-include::studio::partial$pce-configuration-macos.adoc[tag=pce-config,leveloffset=+1]
+include::studio::partial$pce-configuration-macos.adoc[tag=pce-config]
 
-include::studio::partial$pce-configuration-macos.adoc[tag=pce-user-config,leveloffset=+1]
+include::studio::partial$pce-configuration-macos.adoc[tag=pce-user-config]


### PR DESCRIPTION
ref: W-11690846

remove leveloffset for some of the pages to maintain correct heading orders. This is because in the latest version (v7.13), I updated the heading levels to resolve some build warnings for so leveloffset is no longer needed.

Must be merged at the same time as #382.

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released