### PR TITLE
W-10592322: Move reusable EU instructions to docs-reuse

### DIFF
--- a/modules/ROOT/pages/eu-cloud-configuration.adoc
+++ b/modules/ROOT/pages/eu-cloud-configuration.adoc
@@ -1,8 +1,9 @@
-include::studio::partial$eu-cloud-access.adoc[]
+= Access the EU Control Plane from Anypoint Studio
+
+include::reuse::partial$studio/eu-cloud-access.adoc[]
 
 == See Also
 
 * xref:import-api-specification.adoc[Import API Specifications]
 * xref:add-modules-in-studio-to.adoc[Add Modules to Your Project]
 * xref:deploy-mule-application-task.adoc[Deploying a Mule Application to CloudHub]
-


### PR DESCRIPTION
Based on [Slack feedback](https://salesforce-internal.slack.com/archives/C02HGAD2E/p1661351321937449), we can reuse the same instructions that Studio docs have since they are more complete.