### PR TITLE
Updated the first line

### DIFF
--- a/modules/ROOT/pages/including-the-datamapper-plugin.adoc
+++ b/modules/ROOT/pages/including-the-datamapper-plugin.adoc
@@ -5,7 +5,7 @@ endif::[]
 :page-aliases: 6.5@studio::including-the-datamapper-plugin.adoc
 :keywords: datamapper, migration
 
-DataMapper is deprecated as of Mule runtime 3.7.0 and superseded by the xref:transform-message-component-concept-studio.adoc[Transform Message Component].
+DataMapper is deprecated as of Mule runtime 3.7.0 and completely removed in Mule 4.0. To use Dataweave on your Mule flows, use the xref:transform-message-component-concept-studio.adoc[Transform Message Component].
 
 
 [NOTE]


### PR DESCRIPTION
DataMapper is deprecated as of Mule runtime 3.7.0 and completely removed in Mule 4.0. To use Dataweave on your Mule flows, use the xref:transform-message-component-concept-studio.adoc[Transform Message Component].

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released