### PR TITLE
W-23365932: Add Australia Cloud URL to Hyperforce configuration

### DIFF
--- a/modules/ROOT/pages/hyperforce-configuration.adoc
+++ b/modules/ROOT/pages/hyperforce-configuration.adoc
@@ -25,6 +25,7 @@ Follow these steps to configure Anypoint Studio, for other clouds:
 * Canada Cloud: `+https://ca1.platform.mulesoft.com+`
 * Japan Cloud: `+https://jp1.platform.mulesoft.com+`
 * India Cloud: `+https://in1.platform.mulesoft.com+`
+* Australia Cloud: `+https://au1.platform.mulesoft.com+`
 . Click *Apply and Close*.
 +
 image::select-other-region.png["Canada Cloud platform URL in control plane URL field"]


### PR DESCRIPTION
## Summary

Replicates India Cloud change from PR #639 for Australia Cloud.

- **`hyperforce-configuration.adoc`**: Added `https://au1.platform.mulesoft.com` to the list of control plane URLs under *Configure Anypoint Studio to Other Clouds*.

## Test plan

- [ ] Verify the URL renders correctly in the published page.
- [ ] Confirm `au1.platform.mulesoft.com` is the correct platform URL for Australia Cloud.