### PR TITLE
W-23748914: Add United Kingdom Cloud URL to Hyperforce configuration

### DIFF
--- a/modules/ROOT/pages/hyperforce-configuration.adoc
+++ b/modules/ROOT/pages/hyperforce-configuration.adoc
@@ -26,6 +26,7 @@ Follow these steps to configure Anypoint Studio, for other clouds:
 * Japan Cloud: `+https://jp1.platform.mulesoft.com+`
 * India Cloud: `+https://in1.platform.mulesoft.com+`
 * Australia Cloud: `+https://au1.platform.mulesoft.com+`
+* United Kingdom Cloud: `+https://gb1.platform.mulesoft.com+`
 . Click *Apply and Close*.
 +
 image::select-other-region.png["Canada Cloud platform URL in control plane URL field"]


### PR DESCRIPTION
## Summary

Replicates the Australia Cloud change from PR #649 for United Kingdom Cloud.

- **`hyperforce-configuration.adoc`**: Added `+https://gb1.platform.mulesoft.com+` to the list of control plane URLs under *Configure Anypoint Studio to Other Clouds*.

Made with [Cursor](https://cursor.com)